### PR TITLE
Fix: Implement scroll-direction–based mobile navbar visibility

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Home, Trophy, Users } from "lucide-react";
+import { useScrollDirection } from "@/lib/hooks/useScrollDirection";
 
 interface NavbarProps {
   config: Config;
@@ -19,6 +20,7 @@ const navItems = [
 
 const Navbar = ({ config }: NavbarProps) => {
   const pathname = usePathname();
+  const scrollDirection = useScrollDirection()
 
   const isActive = (href: string) => {
     if (href === "/") return pathname === "/";
@@ -73,7 +75,7 @@ const Navbar = ({ config }: NavbarProps) => {
       </header>
 
       {/* Mobile Navbar */}
-      <nav className="md:hidden fixed bottom-4 left-1/2 -translate-x-1/2 z-50">
+      <nav className={`md:hidden fixed bottom-4 left-1/2 transition-transform duration-400 ease-in-out -translate-x-1/2 z-50 ${scrollDirection === "down" ? "translate-y-50" : "translate-y-0"}`}>
         <div className="flex items-center gap-1 rounded-full border border-zinc-200 dark:border-white/10 bg-background/90 backdrop-blur-xl shadow-xl px-2 py-2">
           {navItems.map((item) => {
             const Icon = item.icon;

--- a/lib/hooks/useScrollDirection.ts
+++ b/lib/hooks/useScrollDirection.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef, useState } from "react";
+
+type ScrollDirection = "up" | "down" | "idle";
+
+export function useScrollDirection() {
+  const lastScrollY = useRef(0);
+  const [direction, setDirection] = useState<ScrollDirection>("idle");
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const currentScrollY = window.scrollY;
+
+      if (currentScrollY > lastScrollY.current) {
+        setDirection("down");
+      } else if (currentScrollY < lastScrollY.current) {
+        setDirection("up");
+      }
+
+      lastScrollY.current = currentScrollY;
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  return direction;
+}


### PR DESCRIPTION
## Description
Fixes an issue on mobile devices where the bottom navbar overlaps and hides the footer content.  
The solution introduces scroll-based behavior to hide the navbar when scrolling down and show it again when scrolling up.

## Related Issue
Fixes #15 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots (if applicable)
[Solution Videol-a52.webm](https://github.com/user-attachments/assets/74000048-dfd6-444f-aac2-b137dbc3b32a)
