### PR TITLE
Fix: padding in navbar for desktop and mobile

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -76,7 +76,7 @@ const Navbar = ({ config }: NavbarProps) => {
 
       {/* Mobile Navbar */}
       <nav className={`md:hidden fixed bottom-4 left-1/2 transition-transform duration-400 ease-in-out -translate-x-1/2 z-50 ${scrollDirection === "down" ? "translate-y-50" : "translate-y-0"}`}>
-        <div className="flex items-center gap-1 rounded-full border border-zinc-200 dark:border-white/10 bg-background/90 backdrop-blur-xl shadow-xl">
+        <div className="flex items-center gap-1 rounded-full border border-zinc-200 dark:border-white/10 bg-background/90 backdrop-blur-xl shadow-xl p-1">
           {navItems.map((item) => {
             const Icon = item.icon;
             const active = isActive(item.href);
@@ -95,7 +95,7 @@ const Navbar = ({ config }: NavbarProps) => {
                   }
                 `}
               >
-                <Icon className="h-5 w-5" />
+                <Icon className="h-5.5 w-5.5" />
               </Link>
             );
           })}


### PR DESCRIPTION
## Description
This PR removes unnecessary padding from the navbar to make it more compact and visually aligned across different screen sizes

## Related Issue
Fixes #31 

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unnecessary files added
- [x] PR title is clear and descriptive

## Screenshots (if applicable)

### Desktop
<img width="469" height="83" alt="image" src="https://github.com/user-attachments/assets/20a6dec2-8879-4a1c-874d-11fb55b394dd" />

### Mobile
<img width="164" height="73" alt="image" src="https://github.com/user-attachments/assets/2a42bd9a-9561-492d-b979-6cf3986d9f37" />
